### PR TITLE
Fix crash when moving servers with seamless.

### DIFF
--- a/Data/Scripts/HudLcd/HudLcd.cs
+++ b/Data/Scripts/HudLcd/HudLcd.cs
@@ -49,7 +49,7 @@ namespace Jawastew.HudLcd
         string thisTextFont = textFontDefault;
         bool thisTextFontShadow = textFontShadowDefault;
 
-        IMyTerminalBlock ControlledEntity => MyAPIGateway.Session.LocalHumanPlayer.Controller.ControlledEntity as IMyTerminalBlock;
+        IMyTerminalBlock ControlledEntity => MyAPIGateway.Session?.LocalHumanPlayer?.Controller?.ControlledEntity as IMyTerminalBlock;;
         bool IsControlled => ControlledEntity != null && ControlledEntity.CubeGrid == thisTextPanel.CubeGrid;
 
         // Cache

--- a/Data/Scripts/HudLcd/HudLcd.cs
+++ b/Data/Scripts/HudLcd/HudLcd.cs
@@ -49,7 +49,7 @@ namespace Jawastew.HudLcd
         string thisTextFont = textFontDefault;
         bool thisTextFontShadow = textFontShadowDefault;
 
-        IMyTerminalBlock ControlledEntity => MyAPIGateway.Session?.LocalHumanPlayer?.Controller?.ControlledEntity as IMyTerminalBlock;;
+        IMyTerminalBlock ControlledEntity => MyAPIGateway.Session?.LocalHumanPlayer?.Controller?.ControlledEntity as IMyTerminalBlock;
         bool IsControlled => ControlledEntity != null && ControlledEntity.CubeGrid == thisTextPanel.CubeGrid;
 
         // Cache


### PR DESCRIPTION
When transitioning servers with seamless it would seem either the session itself or part of the controller data is non-existent, null-checking this prevents the crashes.

Crash reference:
```2022-05-02 17:29:23.922 - Thread:   1 ->  Network readers disposed
2022-05-02 17:29:24.348 - Thread:   1 ->  SeamlessClient: Successfully set MyMultiplayer.Static
2022-05-02 17:29:24.398 - Thread:   1 ->  Exception occurred: System.NullReferenceException: Object reference not set to an instance of an object.
   at Jawastew.HudLcd.HudLcd.get_ControlledEntity()
   at Jawastew.HudLcd.HudLcd.get_IsControlled()
   at Jawastew.HudLcd.HudLcd.UpdateBeforeSimulation10()
   at VRage.Game.Components.MyGameLogicComponent.VRage.Game.Entity.EntityComponents.Interfaces.IMyGameLogicComponent.UpdateBeforeSimulation10(Boolean entityUpdate)
   at VRage.Game.Entity.MyGameLogic.<>c.<UpdateBeforeSimulation>b__8_1(MyGameLogicComponent c)
   at VRage.Collections.MyDistributedUpdater`2.Iterate(Action`1 p)
   at VRage.Game.Entity.MyGameLogic.UpdateBeforeSimulation()
   at Sandbox.Game.World.MySector.UpdateBeforeSimulation()
   at Sandbox.Game.World.MySession.UpdateComponents()
   at Sandbox.Game.World.MySession.Update(MyTimeSpan updateTime)
   at Sandbox.MySandboxGame.Update()
   at Sandbox.Engine.Platform.Game.UpdateInternal()
   at Sandbox.Engine.Platform.Game.RunSingleFrame()
   at Sandbox.Engine.Platform.FixedLoop.<>c__DisplayClass11_0.<Run>b__0()
   at Sandbox.Engine.Platform.GenericLoop.Run(VoidAction tickCallback)
   at Sandbox.Engine.Platform.Game.RunLoop()
   at Sandbox.MySandboxGame.Run(Boolean customRenderLoop, Action disposeSplashScreen)
   at SpaceEngineers.MyProgram.Main(String[] args)
2022-05-02 17:29:24.401 - Thread:   1 ->  Showing message```