### PR TITLE
Hiding HUD will hide any HudLcd messages

### DIFF
--- a/Data/Scripts/HudLcd/HudLcd.cs
+++ b/Data/Scripts/HudLcd/HudLcd.cs
@@ -257,7 +257,7 @@ namespace Jawastew.HudLcd
                     Offset: null,
                     TimeToLive: -1,
                     Scale: thisTextScale,
-                    HideHud: false,
+                    HideHud: true,
                     Shadowing: thisTextFontShadow,
                     ShadowColor: Color.Black,
                     Blend: BlendTypeEnum.PostPP,


### PR DESCRIPTION
This is a simple change to make it so that when you hide your hud, any hudlcd Hudmessages will be hidden as well. 

The main reason for doing this is to make taking screenshots when you have lots of LCDs on your screen easier.